### PR TITLE
Rewrite Connection using concurrent-ruby's atoms

### DIFF
--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -200,6 +200,7 @@ module ElasticAPM
     alias :capture_headers? :capture_headers
     alias :capture_env? :capture_env
     alias :disable_send? :disable_send
+    alias :disable_start_message? :disable_start_message
     alias :http_compression? :http_compression
     alias :instrument? :instrument
     alias :verify_server_cert? :verify_server_cert

--- a/lib/elastic_apm/railtie.rb
+++ b/lib/elastic_apm/railtie.rb
@@ -34,8 +34,10 @@ module ElasticAPM
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def start(config)
       if (reason = should_skip?(config))
-        config.alert_logger.info "Skipping because: #{reason}. " \
-          "Start manually with `ElasticAPM.start'"
+        unless config.disable_start_message?
+          config.alert_logger.info "Skipping because: #{reason}. " \
+            "Start manually with `ElasticAPM.start'"
+        end
         return
       end
 

--- a/lib/elastic_apm/transport/connection.rb
+++ b/lib/elastic_apm/transport/connection.rb
@@ -4,59 +4,91 @@ require 'http'
 require 'concurrent'
 require 'zlib'
 
+require 'elastic_apm/transport/connection/proxy_pipe'
+require 'elastic_apm/transport/connection/state'
+
 module ElasticAPM
   module Transport
+    # rubocop:disable Metrics/ClassLength
     # @api private
-    class Connection # rubocop:disable Metrics/ClassLength
+    class Connection
       include Logging
-
-      class FailedToConnectError < InternalError; end
-
-      # @api private
-      # HTTP.rb calls #rewind the body stream which IO.pipes don't support
-      class ModdedIO < IO
-        def self.pipe(ext_enc = nil)
-          super(ext_enc).tap do |rw|
-            rw[0].define_singleton_method(:rewind) { nil }
-          end
-        end
-      end
 
       HEADERS = {
         'Content-Type' => 'application/x-ndjson',
         'Transfer-Encoding' => 'chunked'
       }.freeze
-      GZIP_HEADERS = HEADERS.merge('Content-Encoding' => 'gzip').freeze
+      GZIP_HEADERS = HEADERS.merge(
+        'Content-Encoding' => 'gzip'
+      ).freeze
 
-      # rubocop:disable Metrics/MethodLength
       def initialize(config, metadata)
         @config = config
-        @metadata = metadata.to_json
+        @metadata = JSON.fast_generate(metadata)
 
         @url = config.server_url + '/intake/v2/events'
-
-        headers =
-          (@config.http_compression? ? GZIP_HEADERS : HEADERS).dup
-
-        if (token = config.secret_token)
-          headers['Authorization'] = "Bearer #{token}"
-        end
-
-        @client = HTTP.headers(headers).persistent(@url)
-
-        configure_proxy
-        configure_ssl
+        @headers = build_headers
+        @client = build_client
+        @ssl_context = build_ssl_context
 
         @mutex = Mutex.new
+        @state = State.new
+        @bytes_sent = Concurrent::AtomicFixnum.new(0)
       end
-      # rubocop:enable Metrics/MethodLength
 
-      def configure_proxy
-        unless @config.proxy_address && @config.proxy_port
-          return
+      attr_reader :state
+
+      def write(str)
+        return if @config.disable_send
+
+        connect
+        append(str)
+
+        return true unless @bytes_sent.value >= @config.api_request_size
+
+        debug 'Closing request after reaching api_request_size'
+        flush
+
+        true
+      end
+
+      def connected?
+        state.connected?
+      end
+
+      def flush
+        state.hold do |state|
+          return state.value if state.disconnected?
+
+          debug "Closing request from #{Thread.current.object_id}"
+          @wr&.close
         end
 
-        @client = @client.via(
+        @request_thread&.join(2)
+      end
+
+      private
+
+      def build_headers
+        (
+          @config.http_compression? ? GZIP_HEADERS : HEADERS
+        ).dup.tap do |headers|
+          if (token = @config.secret_token)
+            headers['Authorization'] = "Bearer #{token}"
+          end
+        end
+      end
+
+      def build_client
+        HTTP.headers(@headers).tap do |client|
+          configure_proxy(client)
+        end
+      end
+
+      def configure_proxy(client)
+        return client unless @config.proxy_address && @config.proxy_port
+
+        client.via(
           @config.proxy_address,
           @config.proxy_port,
           @config.proxy_username,
@@ -65,119 +97,72 @@ module ElasticAPM
         )
       end
 
-      def configure_ssl
+      def build_ssl_context
         return unless @config.use_ssl? && @config.server_ca_cert
 
-        @ssl_context = OpenSSL::SSL::SSLContext.new.tap do |context|
+        OpenSSL::SSL::SSLContext.new.tap do |context|
           context.ca_file = @config.server_ca_cert
         end
       end
 
-      def write(str)
-        return if @config.disable_send
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def connect
+        state.hold do |state|
+          return state.value unless state.disconnected?
 
-        connect_unless_connected
-
-        @mutex.synchronize { append(str) }
-
-        return unless @bytes_sent >= @config.api_request_size
-
-        debug 'Closing request after reaching api_request_size'
-        flush
-      rescue FailedToConnectError => e
-        error "Couldn't establish connection to APM Server:\n%p", e
-        flush
-
-        nil
-      end
-
-      def connected?
-        @mutex.synchronize { @connected }
-      end
-
-      def flush
-        @mutex.synchronize do
-          return unless @connected
-
-          debug 'Closing request'
-          @wr.close
-          @conn_thread.join 5 if @conn_thread
-        end
-      end
-
-      private
-
-      # rubocop:disable Metrics/MethodLength
-      def connect_unless_connected
-        @mutex.synchronize do
-          return true if @connected
-
-          debug 'Opening new request'
-
-          reset!
-
-          @rd, @wr = ModdedIO.pipe
+          debug format('Opening new request from %s', Thread.current.object_id)
+          @rd, @wr = ProxyPipe.pipe(on_first_read: state.method(:connected!))
 
           enable_compression! if @config.http_compression?
 
-          perform_request_in_thread
-          wait_for_connection
+          @bytes_sent.value = 0
+
+          open_post_request_in_thread
 
           schedule_closing if @config.api_request_time
 
           append(@metadata)
-
-          true
         end
       end
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
-      # rubocop:disable Metrics/MethodLength
-      def perform_request_in_thread
-        @conn_thread = Thread.new do
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def open_post_request_in_thread
+        @request_thread = Thread.new do
+          state.connecting!
+
           begin
-            @connected = true
-
             resp = @client.post(
               @url,
               body: @rd,
               ssl_context: @ssl_context
-            )
+            ).flush
+
+            if resp&.status == 202
+              debug 'APM Server responded with status 202'
+            elsif resp
+              error "APM Server responded with an error:\n%p", resp.body.to_s
+            end
           rescue Exception => e
-            @connection_error = e
+            error "Couldn't establish connection to APM Server:\n%p", e.inspect
           ensure
-            resp&.flush
-            @connected = false
-          end
+            if @wr
+              @wr.close unless @wr&.closed?
+              @wr = nil
+            end
 
-          if resp&.status == 202
-            debug 'APM Server responded with status 202'
-          elsif resp
-            error "APM Server responded with an error:\n%p", resp.body.to_s
+            @close_task&.cancel
+            state.disconnected!
           end
-
-          resp
         end
       end
-      # rubocop:enable Metrics/MethodLength
-
-      def append(str)
-        bytes =
-          if @config.http_compression
-            @bytes_sent = @wr.tell
-          else
-            @bytes_sent += str.bytesize
-          end
-
-        debug 'Bytes sent during this request: %d', bytes
-
-        @wr.puts(str)
-      end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
       def schedule_closing
         @close_task =
           Concurrent::ScheduledTask.execute(@config.api_request_time) do
             debug 'Closing request after reaching api_request_time'
+            @close_task = nil # inception
             flush
           end
       end
@@ -187,23 +172,20 @@ module ElasticAPM
         @wr = Zlib::GzipWriter.new(@wr)
       end
 
-      def reset!
-        @bytes_sent = 0
-        @connected = false
-        @connection_error = nil
-        @close_task = nil
+      def append(str)
+        @wr.puts(str)
+        update_bytes_sent(str)
+        str
       end
 
-      def wait_for_connection
-        until @connected
-          if (exception = @connection_error)
-            @wr&.close
-            raise FailedToConnectError, exception
-          end
-
-          sleep 0.01
+      def update_bytes_sent(str)
+        if @config.http_compression
+          @bytes_sent.value = @wr.tell
+        else
+          @bytes_sent.update { |curr| curr + str.bytesize }
         end
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/elastic_apm/transport/connection/proxy_pipe.rb
+++ b/lib/elastic_apm/transport/connection/proxy_pipe.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    class Connection
+      # @api private
+      class ProxyPipe
+        def initialize(enc = nil, on_first_read: nil)
+          rd, wr = IO.pipe(enc)
+
+          @read = Read.new(rd, on_first_read)
+          @write = Write.new(wr)
+        end
+
+        attr_reader :read, :write
+
+        # @api private
+        class Write
+          def initialize(io)
+            @io = io
+          end
+
+          def method_missing(name, *args, &block)
+            return @io.send(name, *args, &block) if @io.respond_to?(name)
+            super
+          end
+
+          private
+
+          def respond_to_missing?(name, include_all)
+            @io.respond_to?(name) || super
+          end
+        end
+
+        # @api private
+        class Read
+          def initialize(io, callback = nil)
+            @io = io
+            @callback = callback
+          end
+
+          def readpartial(*args)
+            if @callback
+              @callback.call
+              @callback = nil
+            end
+
+            @io.send(:readpartial, *args)
+          end
+
+          # not supported, but http.rb calls it
+          def rewind
+          end
+
+          def method_missing(name, *args, &block)
+            return @io.send(name, *args, &block) if @io.respond_to?(name)
+            super
+          end
+
+          private
+
+          def respond_to_missing?(name, include_all)
+            @io.respond_to?(name) || super
+          end
+        end
+
+        def self.pipe(enc = nil, on_first_read: nil)
+          pipe = new(enc, on_first_read: on_first_read)
+          [pipe.read, pipe.write]
+        end
+      end
+    end
+  end
+end

--- a/lib/elastic_apm/transport/connection/state.rb
+++ b/lib/elastic_apm/transport/connection/state.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    # @api private
+    class Connection
+      # @api private
+      class State
+        STATES = {
+          disconnected: 0,
+          connecting: 1,
+          connected: 2
+        }.freeze
+
+        def initialize(value: STATES[:disconnected])
+          @atom = Concurrent::AtomicFixnum.new(value)
+        end
+
+        def value=(value)
+          @atom.value = value
+        end
+
+        def value
+          @atom.value
+        end
+
+        def hold
+          @atom.update do
+            yield self
+            nil
+          end
+        end
+
+        def disconnected!
+          self.value = STATES[:disconnected]
+        end
+
+        def disconnected?
+          value == STATES[:disconnected]
+        end
+
+        def connecting!
+          self.value = STATES[:connecting]
+        end
+
+        def connecting?
+          value == STATES[:connecting]
+        end
+
+        def connected!
+          self.value = STATES[:connected]
+        end
+
+        def connected?
+          value == STATES[:connected]
+        end
+
+        def inspect
+          "<#{self.class} #{STATES.key(@atom.value)}>"
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/spies/faraday_spec.rb
+++ b/spec/elastic_apm/spies/faraday_spec.rb
@@ -3,12 +3,12 @@
 require 'faraday'
 
 module ElasticAPM
-  RSpec.describe 'Spy: Faraday' do
+  RSpec.describe 'Spy: Faraday', :intercept do
     let(:client) do
       Faraday.new(url: 'http://example.com')
     end
 
-    it 'spans http calls', :intercept do
+    it 'spans http calls' do
       WebMock.stub_request(:get, %r{http://example.com/.*})
       ElasticAPM.start
 
@@ -26,7 +26,7 @@ module ElasticAPM
       WebMock.reset!
     end
 
-    it 'spans http calls with prefix', :intercept do
+    it 'spans http calls with prefix' do
       WebMock.stub_request(:get, %r{http://example.com/.*})
       ElasticAPM.start
 
@@ -44,7 +44,7 @@ module ElasticAPM
       WebMock.reset!
     end
 
-    it 'spans http calls when url in block', :intercept do
+    it 'spans http calls when url in block' do
       WebMock.stub_request(:get, %r{http://example.com/.*})
       ElasticAPM.start
       client = Faraday.new

--- a/spec/elastic_apm/spies/http_spec.rb
+++ b/spec/elastic_apm/spies/http_spec.rb
@@ -3,8 +3,8 @@
 require 'http'
 
 module ElasticAPM
-  RSpec.describe 'Spy: HTTP.rb' do
-    it 'spans http calls', :intercept do
+  RSpec.describe 'Spy: HTTP.rb', :intercept do
+    it 'spans http calls' do
       WebMock.stub_request(:get, %r{http://example.com/.*})
       ElasticAPM.start
 

--- a/spec/elastic_apm/spies/net_http_spec.rb
+++ b/spec/elastic_apm/spies/net_http_spec.rb
@@ -3,8 +3,8 @@
 require 'net/http'
 
 module ElasticAPM
-  RSpec.describe 'Spy: NetHTTP' do
-    it 'spans http calls', :intercept do
+  RSpec.describe 'Spy: NetHTTP', :intercept do
+    it 'spans http calls' do
       WebMock.stub_request(:get, %r{http://example.com/.*})
       ElasticAPM.start
 
@@ -61,7 +61,7 @@ module ElasticAPM
       WebMock.reset!
     end
 
-    it 'can be disabled', :intercept do
+    it 'can be disabled' do
       WebMock.stub_request(:any, %r{http://example.com/.*})
       ElasticAPM.start
 

--- a/spec/elastic_apm/transport/base_spec.rb
+++ b/spec/elastic_apm/transport/base_spec.rb
@@ -19,7 +19,7 @@ module ElasticAPM
       describe '#stop' do
         let(:config) { Config.new(pool_size: 2) }
 
-        it 'stops all workers' do
+        it 'stops all workers', :mock_intake do
           subject.start
           subject.submit Transaction.new
           subject.stop

--- a/spec/elastic_apm/transport/connection/proxy_pipe_spec.rb
+++ b/spec/elastic_apm/transport/connection/proxy_pipe_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module ElasticAPM
+  module Transport
+    RSpec.describe Connection::ProxyPipe do
+      describe '.pipe' do
+        it 'returns a reader and a writer' do
+          rd, wr = described_class.pipe
+
+          expect(rd).to respond_to(:each)
+          expect(wr).to respond_to(:write)
+
+          expect(rd).to respond_to(:close)
+          expect(wr).to respond_to(:close)
+        end
+
+        it 'pipes from one to the other' do
+          rd, wr = described_class.pipe
+          ran = false
+
+          thread = Thread.new do
+            Thread.stop
+
+            expect(rd.read).to eq '123'
+            ran = true
+          end
+
+          wr.write('1')
+          wr.write('2')
+          wr.write('3')
+
+          sleep 0.1 while thread.status != 'sleep'
+
+          thread.wakeup
+          wr.close
+          thread.join
+
+          expect(ran).to be true
+        end
+
+        it 'calls callbacks before reading and writing' do
+          did_read = double(call: true)
+
+          rd, wr = described_class.pipe(on_first_read: did_read)
+
+          wr.write 'test'
+
+          thread = Thread.new do
+            Thread.stop
+            expect(rd.readpartial(1024)).to eq 'test'
+
+            expect do
+              expect(rd.readpartial(1024)).to eq ''
+            end.to raise_error(EOFError)
+          end
+
+          sleep 0.1 while thread.status != 'sleep'
+
+          thread.wakeup
+          wr.close
+          thread.join
+
+          expect(did_read).to have_received(:call).once
+        end
+      end
+    end
+  end
+end

--- a/spec/elastic_apm/transport/connection_spec.rb
+++ b/spec/elastic_apm/transport/connection_spec.rb
@@ -33,13 +33,10 @@ module ElasticAPM
           threads = (0..9).map do |i|
             Thread.new do
               subject.write(%({"thread": #{i}}))
-              # sleep((10..30).to_a.sample / 10.0)
             end
           end
 
-          threads.each_with_index do |thread, i|
-            thread.join
-          end
+          threads.each(&:join)
 
           expect(subject).to be_connected
 

--- a/spec/elastic_apm/transport/worker_spec.rb
+++ b/spec/elastic_apm/transport/worker_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module ElasticAPM
   module Transport
     RSpec.describe Worker do
-      let(:config) { Config.new logger: Logger.new($stdout), log_level: 0 }
+      let(:config) { Config.new }
       let(:queue) { Queue.new }
       let(:serializers) { Serializers.new config }
       let(:filters) { Filters.new config }
@@ -64,7 +64,7 @@ module ElasticAPM
           thread = Thread.new { subject.work_forever }
           queue.push Worker::StopMessage.new
 
-          Timeout.timeout(1) { loop while thread.alive? }
+          thread.join 1
         end
       end
 

--- a/spec/elastic_apm_spec.rb
+++ b/spec/elastic_apm_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ElasticAPM do
     end
   end
 
-  context 'when running' do
+  context 'when running', :mock_intake do
     before { ElasticAPM.start }
 
     let(:agent) { ElasticAPM.agent }


### PR DESCRIPTION
This hopefully squashes the zlib warnings as well as a race condition when two `write`s open connections at the same time.