### PR TITLE
Init one worker thread per process

### DIFF
--- a/lib/elastic_apm/transport/base.rb
+++ b/lib/elastic_apm/transport/base.rb
@@ -20,22 +20,23 @@ module ElasticAPM
         @filters = Filters.new(config)
 
         @stopped = Mutex.new
-        @pool = Concurrent::FixedThreadPool.new(config.pool_size)
-        @workers = Concurrent::Array.new
-        @supervisor = init_supervisor
+        @workers = Concurrent::Hash.new
       end
 
       def start
         debug 'Starting Transport'
-        ensure_worker_count
-        supervisor.execute
+        boot_worker
       end
 
       def stop
         debug 'Stopping Transport'
         @stopped.try_lock
-        supervisor.shutdown
-        stop_workers
+        send_stop_message
+
+        @workers.each do |_pid, t|
+          t.join(5)
+        end
+        @workers.clear
       end
 
       def submit(resource)
@@ -43,6 +44,8 @@ module ElasticAPM
           warn 'Transport stopping, new events not accepted…'
           return false
         end
+
+        boot_worker
         queue.push(resource, true)
       rescue ThreadError
         warn 'Queue is full (%i items), skipping…', config.api_buffer_size
@@ -58,65 +61,28 @@ module ElasticAPM
       private
 
       attr_reader :config, :filters, :pool, :workers, :supervisor
-
-      def missing_worker
-        config.pool_size - workers.length
-      end
-
-      def ensure_worker_count
-        missing_worker.times { boot_worker }
-      end
-
-      # rubocop:disable Metrics/MethodLength
       def boot_worker
-        return if missing_worker <= 0
-
+        return if @workers[Process.pid] && @workers[Process.pid].alive?
         debug 'Booting worker...'
-        worker = Worker.new(
-          config,
-          queue,
-          serializers: @serializers,
-          filters: @filters
-        )
-        @workers.push worker
 
-        @pool.post do
-          worker.work_forever
-          @workers.delete(worker)
+        @workers[Process.pid] = Thread.new do
+          Worker.new(
+            config,
+            queue,
+            serializers: @serializers,
+            filters: @filters
+          ).work_forever
         end
       end
-      # rubocop:enable Metrics/MethodLength
 
-      def stop_workers
-        return unless @pool.running?
-
-        debug 'Stopping workers'
-        send_stop_messages
-
-        debug 'Shutting down pool'
-        @pool.shutdown
-
-        return if @pool.wait_for_termination(5)
-
-        warn "Worker pool didn't close in 5 secs, killing ..."
-        @pool.kill
-      end
-
-      def send_stop_messages
-        config.pool_size.times { queue.push(Worker::StopMessage.new, true) }
+      def send_stop_message
+        queue.push(Worker::StopMessage.new, true)
       rescue ThreadError
         warn 'Cannot push stop messages to worker queue as it is full'
       end
 
       def stopped?
         @stopped.locked?
-      end
-
-      def init_supervisor
-        @supervisor = Concurrent::TimerTask.new(execution_interval: 2,
-                                                timeout_interval: 1) do
-          ensure_worker_count unless stopped?
-        end
       end
     end
   end


### PR DESCRIPTION
This reduces the number of consuming workers to 1 per process. 
It also ensures that in case an app is preloaded, so the application is started and the code is loaded before the monitored application is forked, the agent can run properly, by ensuring that a worker thread for every forked process is started. 